### PR TITLE
Some fixes in the "Complete workflow example" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ If *yes*, proceed, otherwise email me (the service should start after
 ```
 [host] $ docker run -it --rm --name temp  \
           --volumes-from dachs            \
-          debian
+          debian:jessie
 ```
 
 4. From *inside* the `temp` container, download and save the data:
 ```
+[at-temp] $ apt-get update
+[at-temp] $ apt-get install curl
 [at-temp] $ mkdir arihip
 [at-temp] $ cd arihip
 [at-temp] $ curl -O http://svn.ari.uni-heidelberg.de/svn/gavo/hdinputs/arihip/q.rd

--- a/README.md
+++ b/README.md
@@ -114,19 +114,18 @@ If *yes*, proceed, otherwise email me (the service should start after
 ```
 [at-temp] $ apt-get update
 [at-temp] $ apt-get install curl
-[at-temp] $ mkdir arihip
-[at-temp] $ cd arihip
+[at-temp] $ mkdir /var/gavo/inputs
+[at-temp] $ mkdir arihip && cd arihip
 [at-temp] $ curl -O http://svn.ari.uni-heidelberg.de/svn/gavo/hdinputs/arihip/q.rd
-[at-temp] $ mkdir data
-[at-temp] $ cd data
+[at-temp] $ mkdir data && cd data
 [at-temp] $ curl -O http://dc.g-vo.org/arihip/q/cone/static/data.txt.gz
 ```
 We can now exit from the `temp` container.
 
 5. Finally, we just need to run the `import`/`publish` commands for `dachs`:
 ```
-[from-host] $ docker exec -t dachs gavo import arihip/q
-[from-host] $ docker exec -t dachs gavo publish arihip/q
+[from-host] $ docker exec -t dachs gavo import /var/gavo/inputs/arihip/q.rd
+[from-host] $ docker exec -t dachs gavo publish /var/gavo/inputs/arihip/q.rd
 [from-host] $ docker exec -t dachs gavo serve restart
 ```
 


### PR DESCRIPTION
- use the `debian:jessie` image;
- download curl;
- cd `/var/gavo/inputs`, otherwise the data are not added to the volume; and gavo can not import them.

Bonus question: I do we use a temp image to add data to the volume ? We can do everything we need with `docker exec -it dachs /bin/bash`.